### PR TITLE
Remove GA code

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,7 @@
 
 <link type="text/css" rel="stylesheet" href="master.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_IRB.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_IRB.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_arthritis.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_arthritis.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_clinicalTrial.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_clinicalTrial.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_drugProblem.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_drugProblem.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_equity.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_equity.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_erythematosus.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_erythematosus.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_federalRegulations.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_federalRegulations.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_financialSupport.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_financialSupport.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_molecule.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_molecule.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_multicenter.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_multicenter.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_nondisclosure.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_nondisclosure.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_patent.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_patent.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_royalty.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_royalty.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_stock.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/annotation_stock.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p11.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p11.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p2.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p2.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p3.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p3.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p5.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p5.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p6.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p6.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p8.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p8.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p9.html
+++ b/rcr_DEMO/rcr_conflicts/annotatedcase/wizard_p9.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/case/case02_anthro.html
+++ b/rcr_DEMO/rcr_conflicts/case/case02_anthro.html
@@ -13,12 +13,7 @@
 
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/case/index.html
+++ b/rcr_DEMO/rcr_conflicts/case/index.html
@@ -13,12 +13,7 @@
 
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/conclusion/challengeP01Local.html
+++ b/rcr_DEMO/rcr_conflicts/conclusion/challengeP01Local.html
@@ -11,12 +11,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://ccnmtl.columbia.edu/projects/rcr/rcr_conflicts/c/master.css' />
   <script language="JavaScript" src="http://ccnmtl.columbia.edu/projects/rcr/rcr_conflicts/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/conclusion/challengeP02Local.html
+++ b/rcr_DEMO/rcr_conflicts/conclusion/challengeP02Local.html
@@ -11,12 +11,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='../c/master.css' />
   <script language="JavaScript" src="../j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/conclusion/index.html
+++ b/rcr_DEMO/rcr_conflicts/conclusion/index.html
@@ -11,12 +11,7 @@
   <style type="text/css" media="all">@import "../c/master.css";</style>
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/feedback/index.html
+++ b/rcr_DEMO/rcr_conflicts/feedback/index.html
@@ -12,12 +12,7 @@
   
   
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/bio_dubler.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/bio_dubler.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/bio_murray.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/bio_murray.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/bio_rothman.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/bio_rothman.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/bio_strauss.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/bio_strauss.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/index.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/index.html
@@ -12,12 +12,7 @@
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/indexWithSup.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/indexWithSup.html
@@ -12,12 +12,7 @@
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_aamc_aau.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_aamc_aau.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_agreement.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_agreement.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_blumenthal.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_blumenthal.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_federalproblems.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_federalproblems.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_perversions.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_perversions.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_policies.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_policies.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_tuskegee.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_tuskegee.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/foundation/sideBar_willowbrook.html
+++ b/rcr_DEMO/rcr_conflicts/foundation/sideBar_willowbrook.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/index.html
+++ b/rcr_DEMO/rcr_conflicts/index.html
@@ -11,12 +11,7 @@
 <style type="text/css" media="all">@import "c/master.css";</style>
 <script language="JavaScript" src="j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/introduction/challengeP01Local.html
+++ b/rcr_DEMO/rcr_conflicts/introduction/challengeP01Local.html
@@ -11,12 +11,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://ccnmtl.columbia.edu/projects/rcr/rcr_conflicts/c/master.css' />
   <script language="JavaScript" src="http://ccnmtl.columbia.edu/projects/rcr/rcr_conflicts/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/introduction/challengeP02Local.html
+++ b/rcr_DEMO/rcr_conflicts/introduction/challengeP02Local.html
@@ -11,12 +11,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='../c/master.css' />
   <script language="JavaScript" src="../j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/introduction/index.html
+++ b/rcr_DEMO/rcr_conflicts/introduction/index.html
@@ -10,12 +10,7 @@
   
   <style type="text/css" media="all">@import "../c/master.css";</style>
   <script language="JavaScript" src="../j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/introduction/objectives.html
+++ b/rcr_DEMO/rcr_conflicts/introduction/objectives.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/introduction/pollAnswers.html
+++ b/rcr_DEMO/rcr_conflicts/introduction/pollAnswers.html
@@ -10,12 +10,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://www.columbia.edu/~crivano/rcr/c/master.css' />
   <script language="JavaScript" src="http://wwww.columbia.edu/~crivano/rcr/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/introduction/pollQuestions.html
+++ b/rcr_DEMO/rcr_conflicts/introduction/pollQuestions.html
@@ -10,12 +10,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://www.columbia.edu/~crivano/rcr/c/master.css' />
   <script language="JavaScript" src="http://wwww.columbia.edu/~crivano/rcr/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_01.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_01.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_02.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_02.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_03.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_03.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_04.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_04.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_05.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_05.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_06.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_06.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_07.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_07.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_08.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_08.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_09.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_09.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case01_answer_10.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case01_answer_10.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case02_answer_01.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case02_answer_01.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case02_answer_02.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case02_answer_02.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case02_answer_03.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case02_answer_03.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case02_answer_04.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case02_answer_04.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/case02_answer_05.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/case02_answer_05.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/q_a/index.html
+++ b/rcr_DEMO/rcr_conflicts/q_a/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/winConfirm.html
+++ b/rcr_DEMO/rcr_conflicts/winConfirm.html
@@ -10,12 +10,7 @@
   
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/winCredits.html
+++ b/rcr_DEMO/rcr_conflicts/winCredits.html
@@ -10,12 +10,7 @@
   
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/winFeedback.html
+++ b/rcr_DEMO/rcr_conflicts/winFeedback.html
@@ -10,12 +10,7 @@
   
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_DEMO/rcr_conflicts/winHelp.html
+++ b/rcr_DEMO/rcr_conflicts/winHelp.html
@@ -10,12 +10,7 @@
   
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_authorship/annotatedcase/index.html
+++ b/rcr_authorship/annotatedcase/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />

--- a/rcr_authorship/foundation/index.html
+++ b/rcr_authorship/foundation/index.html
@@ -13,12 +13,7 @@
 
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_authorship/introduction/index_bkup.html
+++ b/rcr_authorship/introduction/index_bkup.html
@@ -12,12 +12,7 @@
 
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_authorship/winCredits.html
+++ b/rcr_authorship/winCredits.html
@@ -11,12 +11,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />

--- a/rcr_authorship/winCredits_old.html
+++ b/rcr_authorship/winCredits_old.html
@@ -11,12 +11,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />

--- a/rcr_authorship/winFeedback.html
+++ b/rcr_authorship/winFeedback.html
@@ -11,12 +11,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />

--- a/rcr_authorship/winNavigation.html
+++ b/rcr_authorship/winNavigation.html
@@ -11,12 +11,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />

--- a/rcr_authorship/winResources.html
+++ b/rcr_authorship/winResources.html
@@ -12,12 +12,7 @@
 
 <script language="JavaScript" src="j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />

--- a/rcr_conflicts/annotatedcase/annotation_IRB.html
+++ b/rcr_conflicts/annotatedcase/annotation_IRB.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_arthritis.html
+++ b/rcr_conflicts/annotatedcase/annotation_arthritis.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_clinicalTrial.html
+++ b/rcr_conflicts/annotatedcase/annotation_clinicalTrial.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_drugProblem.html
+++ b/rcr_conflicts/annotatedcase/annotation_drugProblem.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_equity.html
+++ b/rcr_conflicts/annotatedcase/annotation_equity.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_erythematosus.html
+++ b/rcr_conflicts/annotatedcase/annotation_erythematosus.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_federalRegulations.html
+++ b/rcr_conflicts/annotatedcase/annotation_federalRegulations.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_financialSupport.html
+++ b/rcr_conflicts/annotatedcase/annotation_financialSupport.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_molecule.html
+++ b/rcr_conflicts/annotatedcase/annotation_molecule.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_multicenter.html
+++ b/rcr_conflicts/annotatedcase/annotation_multicenter.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_nondisclosure.html
+++ b/rcr_conflicts/annotatedcase/annotation_nondisclosure.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_patent.html
+++ b/rcr_conflicts/annotatedcase/annotation_patent.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_royalty.html
+++ b/rcr_conflicts/annotatedcase/annotation_royalty.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/annotation_stock.html
+++ b/rcr_conflicts/annotatedcase/annotation_stock.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/index.html
+++ b/rcr_conflicts/annotatedcase/index.html
@@ -25,12 +25,7 @@
 
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p10.html
+++ b/rcr_conflicts/annotatedcase/wizard_p10.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p11.html
+++ b/rcr_conflicts/annotatedcase/wizard_p11.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p3_1.html
+++ b/rcr_conflicts/annotatedcase/wizard_p3_1.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p3_2.html
+++ b/rcr_conflicts/annotatedcase/wizard_p3_2.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p4.html
+++ b/rcr_conflicts/annotatedcase/wizard_p4.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p6.html
+++ b/rcr_conflicts/annotatedcase/wizard_p6.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p7.html
+++ b/rcr_conflicts/annotatedcase/wizard_p7.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/annotatedcase/wizard_p9.html
+++ b/rcr_conflicts/annotatedcase/wizard_p9.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/wizard.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/case/case02_anthro.html
+++ b/rcr_conflicts/case/case02_anthro.html
@@ -13,12 +13,7 @@
 
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/case/index.html
+++ b/rcr_conflicts/case/index.html
@@ -13,12 +13,7 @@
 
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/conclusion/index.html
+++ b/rcr_conflicts/conclusion/index.html
@@ -11,12 +11,7 @@
   <link type="text/css" rel="stylesheet" title="master styles" href="../c/master.css">
   <script language="JavaScript" src="../j/newConsole.js"></script>
 <script language="JavaScript" src="../j/challques.js"></script> 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/feedback/index.html
+++ b/rcr_conflicts/feedback/index.html
@@ -12,12 +12,7 @@
   
   
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/bio_dubler.html
+++ b/rcr_conflicts/foundation/bio_dubler.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/bio_murray.html
+++ b/rcr_conflicts/foundation/bio_murray.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/bio_rothman.html
+++ b/rcr_conflicts/foundation/bio_rothman.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/bio_strauss.html
+++ b/rcr_conflicts/foundation/bio_strauss.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/index.html
+++ b/rcr_conflicts/foundation/index.html
@@ -12,12 +12,7 @@
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/indexWithSup.html
+++ b/rcr_conflicts/foundation/indexWithSup.html
@@ -12,12 +12,7 @@
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_aamc_aau.html
+++ b/rcr_conflicts/foundation/sideBar_aamc_aau.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_agreement.html
+++ b/rcr_conflicts/foundation/sideBar_agreement.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_blumenthal.html
+++ b/rcr_conflicts/foundation/sideBar_blumenthal.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_federalproblems.html
+++ b/rcr_conflicts/foundation/sideBar_federalproblems.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_perversions.html
+++ b/rcr_conflicts/foundation/sideBar_perversions.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_policies.html
+++ b/rcr_conflicts/foundation/sideBar_policies.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_tuskegee.html
+++ b/rcr_conflicts/foundation/sideBar_tuskegee.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/foundation/sideBar_willowbrook.html
+++ b/rcr_conflicts/foundation/sideBar_willowbrook.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/index.html
+++ b/rcr_conflicts/index.html
@@ -9,12 +9,7 @@
 <title>Responsible Conduct Research : Conflicts of Interest</title>
 <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/introduction/index_bkup.html
+++ b/rcr_conflicts/introduction/index_bkup.html
@@ -10,12 +10,7 @@
 
   <link type="text/css" rel="stylesheet" title="master styles" href="../c/master.css">
   <script language="JavaScript" src="../j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/introduction/objectives.html
+++ b/rcr_conflicts/introduction/objectives.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/introduction/pollAnswers.html
+++ b/rcr_conflicts/introduction/pollAnswers.html
@@ -10,12 +10,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://www.columbia.edu/~crivano/rcr/c/master.css' />
   <script language="JavaScript" src="http://wwww.columbia.edu/~crivano/rcr/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/introduction/pollQuestions.html
+++ b/rcr_conflicts/introduction/pollQuestions.html
@@ -10,12 +10,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://www.columbia.edu/~crivano/rcr/c/master.css' />
   <script language="JavaScript" src="http://wwww.columbia.edu/~crivano/rcr/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_01.html
+++ b/rcr_conflicts/q_a/case01_answer_01.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_02.html
+++ b/rcr_conflicts/q_a/case01_answer_02.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_03.html
+++ b/rcr_conflicts/q_a/case01_answer_03.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_04.html
+++ b/rcr_conflicts/q_a/case01_answer_04.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_05.html
+++ b/rcr_conflicts/q_a/case01_answer_05.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_06.html
+++ b/rcr_conflicts/q_a/case01_answer_06.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_07.html
+++ b/rcr_conflicts/q_a/case01_answer_07.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_08.html
+++ b/rcr_conflicts/q_a/case01_answer_08.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_09.html
+++ b/rcr_conflicts/q_a/case01_answer_09.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case01_answer_10.html
+++ b/rcr_conflicts/q_a/case01_answer_10.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case02_answer_01.html
+++ b/rcr_conflicts/q_a/case02_answer_01.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case02_answer_02.html
+++ b/rcr_conflicts/q_a/case02_answer_02.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case02_answer_03.html
+++ b/rcr_conflicts/q_a/case02_answer_03.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case02_answer_04.html
+++ b/rcr_conflicts/q_a/case02_answer_04.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/case02_answer_05.html
+++ b/rcr_conflicts/q_a/case02_answer_05.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/q_a/index.html
+++ b/rcr_conflicts/q_a/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/winAbout.html
+++ b/rcr_conflicts/winAbout.html
@@ -11,12 +11,7 @@
 <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
 <script language="JavaScript" src="j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/winConfirm.html
+++ b/rcr_conflicts/winConfirm.html
@@ -10,12 +10,7 @@
   
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/winCredits.html
+++ b/rcr_conflicts/winCredits.html
@@ -10,12 +10,7 @@
 
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/winCredits_old.html
+++ b/rcr_conflicts/winCredits_old.html
@@ -10,12 +10,7 @@
 
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/winFeedback.html
+++ b/rcr_conflicts/winFeedback.html
@@ -10,12 +10,7 @@
   
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/winNavigation.html
+++ b/rcr_conflicts/winNavigation.html
@@ -10,12 +10,7 @@
 
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_conflicts/winResources.html
+++ b/rcr_conflicts/winResources.html
@@ -22,12 +22,7 @@
 
   <script language="JavaScript" src="j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/annotatedcase/index.html
+++ b/rcr_data/annotatedcase/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/introduction/index_bkup.html
+++ b/rcr_data/introduction/index_bkup.html
@@ -11,12 +11,7 @@
 
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/q_a/index.html
+++ b/rcr_data/q_a/index.html
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"        "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html><head><title>Responsible Conduct of Research : Data Acquisition and Management</title>  <style type="text/css" media="all">@import "../c/master.css";</style>  <script language="JavaScript" src="../j/newConsole.js"></script><script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+<?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"        "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html><head><title>Responsible Conduct of Research : Data Acquisition and Management</title>  <style type="text/css" media="all">@import "../c/master.css";</style>  <script language="JavaScript" src="../j/newConsole.js"></script>
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/winCredits.html
+++ b/rcr_data/winCredits.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/winCredits_old.html
+++ b/rcr_data/winCredits_old.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/winFeedback.html
+++ b/rcr_data/winFeedback.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/winNavigation.html
+++ b/rcr_data/winNavigation.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_data/winResources.html
+++ b/rcr_data/winResources.html
@@ -11,12 +11,7 @@
 	
 	<script language="JavaScript" src="j/newConsole.js"></script> 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/annotatedcase/index.html
+++ b/rcr_mentoring/annotatedcase/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/annotatedcase/wizard_p2_1.html
+++ b/rcr_mentoring/annotatedcase/wizard_p2_1.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/annotatedcase/wizard_p2_2.html
+++ b/rcr_mentoring/annotatedcase/wizard_p2_2.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/annotatedcase/wizard_p5.html
+++ b/rcr_mentoring/annotatedcase/wizard_p5.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/case/ack.html
+++ b/rcr_mentoring/case/ack.html
@@ -7,12 +7,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/case/index.html
+++ b/rcr_mentoring/case/index.html
@@ -13,12 +13,7 @@
 
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/conclusion/index.html
+++ b/rcr_mentoring/conclusion/index.html
@@ -11,12 +11,7 @@
   <style type="text/css" media="all">@import "../c/master.css";</style>
   <script language="JavaScript" src="../j/newConsole.js"></script>
 <script language="JavaScript" src="../j/challques.js"></script> 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/conclusion/objectives.html
+++ b/rcr_mentoring/conclusion/objectives.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/feedback/index.html
+++ b/rcr_mentoring/feedback/index.html
@@ -12,12 +12,7 @@
   
   
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/bio_colten.html
+++ b/rcr_mentoring/foundation/bio_colten.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/bio_despommier.html
+++ b/rcr_mentoring/foundation/bio_despommier.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/bio_helfand.html
+++ b/rcr_mentoring/foundation/bio_helfand.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/bio_lythcott.html
+++ b/rcr_mentoring/foundation/bio_lythcott.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/bio_yardley.html
+++ b/rcr_mentoring/foundation/bio_yardley.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/index.html
+++ b/rcr_mentoring/foundation/index.html
@@ -12,12 +12,7 @@
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_agreement.html
+++ b/rcr_mentoring/foundation/sideBar_agreement.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_award.html
+++ b/rcr_mentoring/foundation/sideBar_award.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_cole.html
+++ b/rcr_mentoring/foundation/sideBar_cole.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_fellows.html
+++ b/rcr_mentoring/foundation/sideBar_fellows.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_howard.html
+++ b/rcr_mentoring/foundation/sideBar_howard.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_idp.html
+++ b/rcr_mentoring/foundation/sideBar_idp.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_international.html
+++ b/rcr_mentoring/foundation/sideBar_international.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_ombudsperson.html
+++ b/rcr_mentoring/foundation/sideBar_ombudsperson.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_rosalyn.html
+++ b/rcr_mentoring/foundation/sideBar_rosalyn.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/sideBar_tips.html
+++ b/rcr_mentoring/foundation/sideBar_tips.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/wizard01.html
+++ b/rcr_mentoring/foundation/wizard01.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/wizard02.html
+++ b/rcr_mentoring/foundation/wizard02.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/foundation/wizard03.html
+++ b/rcr_mentoring/foundation/wizard03.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/index.html
+++ b/rcr_mentoring/index.html
@@ -11,12 +11,7 @@
 <style type="text/css" media="all">@import "c/master.css";</style>
 <script language="JavaScript" src="j/newConsole.js" type="text/javascript"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/introduction/index_bkup.html
+++ b/rcr_mentoring/introduction/index_bkup.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "../c/master.css";</style>
   <script language="JavaScript" src="../j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/introduction/objectives.html
+++ b/rcr_mentoring/introduction/objectives.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/introduction/pollAnswers.html
+++ b/rcr_mentoring/introduction/pollAnswers.html
@@ -10,12 +10,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://www.columbia.edu/~crivano/rcr/c/master.css' />
   <script language="JavaScript" src="http://wwww.columbia.edu/~crivano/rcr/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/introduction/pollQuestions.html
+++ b/rcr_mentoring/introduction/pollQuestions.html
@@ -10,12 +10,7 @@
   <Link Rel='stylesheet' Type='text/css' Href='http://ccnmtl.columbia.edu/projects/rcr/rcr_mentoring/c/master.css' />
   <script language="JavaScript" src="http://ccnmtl.columbia.edu/projects/rcr/rcr_mentoring/j/newConsole.js"></script>
   
- <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+ 
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_01.html
+++ b/rcr_mentoring/q_a/case01_answer_01.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_02.html
+++ b/rcr_mentoring/q_a/case01_answer_02.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_03.html
+++ b/rcr_mentoring/q_a/case01_answer_03.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_04.html
+++ b/rcr_mentoring/q_a/case01_answer_04.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_05.html
+++ b/rcr_mentoring/q_a/case01_answer_05.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_06.html
+++ b/rcr_mentoring/q_a/case01_answer_06.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_07.html
+++ b/rcr_mentoring/q_a/case01_answer_07.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_08.html
+++ b/rcr_mentoring/q_a/case01_answer_08.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/case01_answer_09.html
+++ b/rcr_mentoring/q_a/case01_answer_09.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/q_a/index.html
+++ b/rcr_mentoring/q_a/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/winAbout.html
+++ b/rcr_mentoring/winAbout.html
@@ -11,12 +11,7 @@
 <style type="text/css" media="all">@import "c/master.css";</style>
 <script language="JavaScript" src="j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/winConfirm.html
+++ b/rcr_mentoring/winConfirm.html
@@ -10,12 +10,7 @@
   
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/winCredits.html
+++ b/rcr_mentoring/winCredits.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/winCredits_old.html
+++ b/rcr_mentoring/winCredits_old.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/winFeedback.html
+++ b/rcr_mentoring/winFeedback.html
@@ -10,12 +10,7 @@
   
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/winNavigation.html
+++ b/rcr_mentoring/winNavigation.html
@@ -10,12 +10,7 @@
 
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_mentoring/winResources.html
+++ b/rcr_mentoring/winResources.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_misconduct/winCredits.html
+++ b/rcr_misconduct/winCredits.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_misconduct/winCredits_old.html
+++ b/rcr_misconduct/winCredits_old.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_misconduct/winFeedback.html
+++ b/rcr_misconduct/winFeedback.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_misconduct/winHelp.html
+++ b/rcr_misconduct/winHelp.html
@@ -10,12 +10,7 @@
   
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_misconduct/winNavigation.html
+++ b/rcr_misconduct/winNavigation.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_misconduct/winResources.html
+++ b/rcr_misconduct/winResources.html
@@ -9,12 +9,7 @@
 
 	<title>Responsible Conduct of Research : Research Misconduct</title> <style type="text/css" media="all">@import "c/master.css";</style> <script language="JavaScript" src="j/newConsole.js"></script> 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/annotatedcase/index.html
+++ b/rcr_neuro/annotatedcase/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/annotatedcase/wizard_cs01_01.html
+++ b/rcr_neuro/annotatedcase/wizard_cs01_01.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/annotatedcase/wizard_cs01_02.html
+++ b/rcr_neuro/annotatedcase/wizard_cs01_02.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/annotatedcase/wizard_cs01_03.html
+++ b/rcr_neuro/annotatedcase/wizard_cs01_03.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/annotatedcase/wizard_cs02_01.html
+++ b/rcr_neuro/annotatedcase/wizard_cs02_01.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/annotatedcase/wizard_cs02_02.html
+++ b/rcr_neuro/annotatedcase/wizard_cs02_02.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/wizard.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/case/ack1.html
+++ b/rcr_neuro/case/ack1.html
@@ -10,12 +10,7 @@
 
 <link type="text/css" rel="stylesheet" title="master styles" href="../c/annotations.css">
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/conclusion/index.html
+++ b/rcr_neuro/conclusion/index.html
@@ -6,12 +6,7 @@
 			Responsible Conduct of Research : Neuroethics
 		</title>
 <style type="text/css" media="all">@import "../c/master.css";</style> <script language="JavaScript" src="../j/newConsole.js"></script>
-	<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+	
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/conclusion/objectives.html
+++ b/rcr_neuro/conclusion/objectives.html
@@ -12,12 +12,7 @@
 
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/feedback/index.html
+++ b/rcr_neuro/feedback/index.html
@@ -13,12 +13,7 @@
   
   
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/foundation/sideBar_confidentiality.html
+++ b/rcr_neuro/foundation/sideBar_confidentiality.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/foundation/sideBar_consent.html
+++ b/rcr_neuro/foundation/sideBar_consent.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/foundation/sideBar_human.html
+++ b/rcr_neuro/foundation/sideBar_human.html
@@ -7,12 +7,7 @@
 
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/index.html
+++ b/rcr_neuro/index.html
@@ -21,12 +21,7 @@
 <script language="JavaScript" src="j/newConsole.js"></script>
 
 <!-- Google Analytics -->
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/introduction/index.html
+++ b/rcr_neuro/introduction/index.html
@@ -19,12 +19,7 @@
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
 <!-- Google Analytics -->
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/introduction/objectives.html
+++ b/rcr_neuro/introduction/objectives.html
@@ -12,12 +12,7 @@
 
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case01_answer_01.html
+++ b/rcr_neuro/q_a/case01_answer_01.html
@@ -11,12 +11,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case01_answer_02.html
+++ b/rcr_neuro/q_a/case01_answer_02.html
@@ -13,12 +13,7 @@
 
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case01_answer_03.html
+++ b/rcr_neuro/q_a/case01_answer_03.html
@@ -8,12 +8,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case01_answer_04.html
+++ b/rcr_neuro/q_a/case01_answer_04.html
@@ -8,12 +8,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case01_answer_05.html
+++ b/rcr_neuro/q_a/case01_answer_05.html
@@ -8,12 +8,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case02_answer_01.html
+++ b/rcr_neuro/q_a/case02_answer_01.html
@@ -8,12 +8,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case02_answer_02.html
+++ b/rcr_neuro/q_a/case02_answer_02.html
@@ -8,12 +8,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/case02_answer_03.html
+++ b/rcr_neuro/q_a/case02_answer_03.html
@@ -8,12 +8,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/q_a/index.html
+++ b/rcr_neuro/q_a/index.html
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"        "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html><head><title>Responsible Conduct of Research : Neuroethics</title>  <style type="text/css" media="all">@import "../c/master.css";</style>  <script language="JavaScript" src="../j/newConsole.js"></script><script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+<?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"        "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html><head><title>Responsible Conduct of Research : Neuroethics</title>  <style type="text/css" media="all">@import "../c/master.css";</style>  <script language="JavaScript" src="../j/newConsole.js"></script>
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/winAbout.html
+++ b/rcr_neuro/winAbout.html
@@ -11,12 +11,7 @@
 <style type="text/css" media="all">@import "c/master.css";</style>
 <script language="JavaScript" src="j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/winConfirm.html
+++ b/rcr_neuro/winConfirm.html
@@ -11,12 +11,7 @@
 <style type="text/css" media="all">@import "c/master.css";</style>
 <script language="JavaScript" src="j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/winCredits.html
+++ b/rcr_neuro/winCredits.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/winFeedback.html
+++ b/rcr_neuro/winFeedback.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/winHelp.html
+++ b/rcr_neuro/winHelp.html
@@ -10,12 +10,7 @@
   
   <link type="text/css" rel="stylesheet" title="master styles" href="c/master.css">
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/winNavigation.html
+++ b/rcr_neuro/winNavigation.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_neuro/winResources.html
+++ b/rcr_neuro/winResources.html
@@ -11,12 +11,7 @@
 	
 	<script language="JavaScript" src="j/newConsole.js"></script> 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/annotatedcase/index.html
+++ b/rcr_science/annotatedcase/index.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/annotatedcase/index_old.html
+++ b/rcr_science/annotatedcase/index_old.html
@@ -12,12 +12,7 @@
   <script language="JavaScript" src="../j/newConsole.js"></script>
 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/case/index.html
+++ b/rcr_science/case/index.html
@@ -12,12 +12,7 @@
 
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/foundation/bio_berkman.html
+++ b/rcr_science/foundation/bio_berkman.html
@@ -12,12 +12,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/foundation/bio_neckerman.html
+++ b/rcr_science/foundation/bio_neckerman.html
@@ -12,12 +12,7 @@
 <style type="text/css" media="all">@import "../c/annotations.css";</style>
 <script language="JavaScript" src="scripts/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/introduction/index.html
+++ b/rcr_science/introduction/index.html
@@ -13,12 +13,7 @@
 <script language="JavaScript" src="../j/newConsole.js"></script>
 <script language="JavaScript" src="../j/challques.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/introduction/index_bkup.html
+++ b/rcr_science/introduction/index_bkup.html
@@ -12,12 +12,7 @@
 
 <script language="JavaScript" src="../j/newConsole.js"></script>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/q_a/index.html
+++ b/rcr_science/q_a/index.html
@@ -1,9 +1,4 @@
-﻿<?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"        "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html><head><title>Responsible Conduct of Research : Collaborative Science</title>  <style type="text/css" media="all">@import "../c/master.css";</style>  <script language="JavaScript" src="../j/newConsole.js"></script><script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+﻿<?xml version="1.0" encoding="iso-8859-1"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"        "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html><head><title>Responsible Conduct of Research : Collaborative Science</title>  <style type="text/css" media="all">@import "../c/master.css";</style>  <script language="JavaScript" src="../j/newConsole.js"></script>
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/winCredits.html
+++ b/rcr_science/winCredits.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/winCredits_old.html
+++ b/rcr_science/winCredits_old.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/winFeedback.html
+++ b/rcr_science/winFeedback.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/winNavigation.html
+++ b/rcr_science/winNavigation.html
@@ -10,12 +10,7 @@
 
   <style type="text/css" media="all">@import "c/master.css";</style>
   <script language="JavaScript" src="j/newConsole.js"></script>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>

--- a/rcr_science/winResources.html
+++ b/rcr_science/winResources.html
@@ -11,12 +11,7 @@
 	
 	<script language="JavaScript" src="j/newConsole.js"></script> 
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-311226-9";
-urchinTracker();
-</script>
+
 
 <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
 <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>


### PR DESCRIPTION
This was done with the following command:
```
find . -name "*.html" -exec perl -p0i -e 's+<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">\n</script>\n<script type="text/javascript">\n_uacct = "UA-311226-9";\nurchinTracker\(\);\n</script>++g' {} +
```

I ended up having to use perl over sed because I had trouble making the match in sed.